### PR TITLE
DOC: Remove the year reference from `docs/get_a_hold_of_your_donuts.md`

### DIFF
--- a/docs/get_a_hold_of_your_donuts.md
+++ b/docs/get_a_hold_of_your_donuts.md
@@ -2,11 +2,11 @@
 
 One of the most important aspects of Brainhacks is having donuts in place! We can hear that you are stressed already for how on earth you will be going for the right selection of donuts that will be inclusive enough for all of your attendee's palate and preference!
 
-Yeah,we know it is a big responsibility! But as you know, every well-done responsibility comes with a big joy afterward! As Brainhack Global 2019 organizing team, this year we are going bold, we are taking the initiative and helping you all in your selection of donuts! Don't worry, we got you!
+Yeah, we know it is a big responsibility! But as you know, every well-done responsibility comes with a big joy afterward! As the Brainhack Global Organizing Team, we are going bold, we are taking the initiative and helping you all in your selection of donuts! Don't worry, we got you!
 
 How? Here is the explanation. We went out to the street, and asked tons of people that how a perfect donut should be like! And we curated the results here... Pffff ooookkay :roll_eyes: , you got me! We didn't run such a survey! Let say our ethics application hasn't gone through yet, but as if, right? 
 
-Well, in such case here is our selection of sources for the description of perfect donuts and the science behind it! So we are sure that it will help! Please have a look at, we promise you that they are really good! 
+Well, in such case here is our selection of sources for the description of perfect donuts and the science behind it! So we are sure that it will help! Please have a look at, we promise you that they are really good!
 
 **Warning!** The following contents might make you carving for donuts! So get the wallets ready!
 


### PR DESCRIPTION
Remove the year reference from `docs/get_a_hold_of_your_donuts.md`.

Rationale: the materials also apply to potential future editions.